### PR TITLE
Add multi stage builds support in collector

### DIFF
--- a/src/collect.py
+++ b/src/collect.py
@@ -17,12 +17,12 @@ def collect():
 
         for line in f.readlines():
 
-            built_state_match_re = re.match('(FROM\s+.*)AS\s+([^\s]+)\s*$', line, re.IGNORECASE)
+            built_state_match_re = re.match('(FROM\s+\S+)\s+AS\s+(\S+)\s*$', line, re.IGNORECASE)
             if built_state_match_re:
                 line = built_state_match_re.groups()[0]
                 stages.append(built_state_match_re.groups()[1])
 
-            owner_repo_tag_match = re.match('FROM\s+([^\/\s:]*)/([^\/\s:]*):([^\/\s:]*)$', line, re.IGNORECASE)
+            owner_repo_tag_match = re.match('FROM\s+(\S+)/(\S+):(\S+)\s*$', line, re.IGNORECASE)
             if owner_repo_tag_match:
                 owner = owner_repo_tag_match.groups()[0]
                 repo = owner_repo_tag_match.groups()[1]
@@ -33,7 +33,7 @@ def collect():
                 }
                 continue
 
-            owner_repo_match = re.match('FROM\s+([^\/\s:]*)/([^\/\s:]*)$', line, re.IGNORECASE)
+            owner_repo_match = re.match('FROM\s+(\S+)/(\S+)\s*$', line, re.IGNORECASE)
             if owner_repo_match:
                 owner = owner_repo_match.groups()[0]
                 repo = owner_repo_match.groups()[1]
@@ -43,7 +43,7 @@ def collect():
                 }
                 continue
 
-            repo_tag_match = re.match('FROM\s+([^\/\s:]*):([^\/\s:]*)$', line, re.IGNORECASE)
+            repo_tag_match = re.match('FROM\s+(\S+):(\S+)\s*$', line, re.IGNORECASE)
             if repo_tag_match:
                 repo = repo_tag_match.groups()[0]
                 tag = repo_tag_match.groups()[1]
@@ -53,7 +53,7 @@ def collect():
                 }
                 continue
 
-            repo_match = re.match('FROM\s+([^\/\s:]*)$', line, re.IGNORECASE)
+            repo_match = re.match('FROM\s+(\S+)\s*$', line, re.IGNORECASE)
             if repo_match:
                 repo = repo_match.groups()[0]
 

--- a/src/collect.py
+++ b/src/collect.py
@@ -13,7 +13,15 @@ def collect():
     collected_dependencies = {}
 
     with open(dockerfile_path, 'r') as f:
+        stages = []
+
         for line in f.readlines():
+
+            built_state_match_re = re.match('(FROM\s+.*)AS\s+([^\s]+)\s*$', line, re.IGNORECASE)
+            if built_state_match_re:
+                line = built_state_match_re.groups()[0]
+                stages.append(built_state_match_re.groups()[1])
+
             owner_repo_tag_match = re.match('FROM\s+([^\/\s:]*)/([^\/\s:]*):([^\/\s:]*)$', line, re.IGNORECASE)
             if owner_repo_tag_match:
                 owner = owner_repo_tag_match.groups()[0]
@@ -48,6 +56,10 @@ def collect():
             repo_match = re.match('FROM\s+([^\/\s:]*)$', line, re.IGNORECASE)
             if repo_match:
                 repo = repo_match.groups()[0]
+
+                if repo in stages:
+                    # if this is a stage built before
+                    continue
 
                 collected_dependencies[repo] = {
                     'constraint': 'latest',

--- a/tests/collector/basic/repo/Dockerfile
+++ b/tests/collector/basic/repo/Dockerfile
@@ -1,7 +1,10 @@
 # a comment
 FROM ubuntu
 
-from dependencies/collector-python-pip:1.0
+from dependencies/collector-python-pip:1.0 AS step
+
+from step
+
 # more comments
 FROM python:3.6-alpine
 CMD ["test"]


### PR DESCRIPTION
Hi,

I have noticed that [multi stage builds](https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds) was not yet supported in the collector.

I have tried to implement it by rewriting processed line and skipping dependency resolution for previously built stages?

Signed-off-by: Thibault Jamet <tjamet@users.noreply.github.com>